### PR TITLE
Add DefaultAzureCredential as fallback in case of no auth config

### DIFF
--- a/certbot_dns_azure/__init__.py
+++ b/certbot_dns_azure/__init__.py
@@ -24,16 +24,36 @@ Configuration
 Use of this plugin requires a configuration file containing Azure API
 credentials or information.
 
-This plugin supported API authentication using either Service Principals or
-utilising a Managed Identity assigned to the virtual machine.
+This plugin supports API authentication using Service Principals,
+Managed Identity (both system and user-assigned), or the
+`DefaultAzureCredential <https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python>`__
+chain.
 
-Regardless which authentication method used, the identity will need the
+Using the default Azure credential chain is the easiest and most flexible.
+The plugin will automatically use this if nothing else is configured in the INI
+config file. It will allow you to authenticate with any of the following:
+
+* A Service Principal configured by environment variables.
+* Managed Identity.
+* Tokens stored in a shared token cache.
+* Visual Studio Code.
+* Azure CLI.
+* Azure Powershell.
+
+Regardless of which authentication method is used, the identity will need the
 "DNS Zone Contributor" role assigned to it.
 
 As multiple Azure DNS Zones in multiple resource groups can exist, the config
 file needs a mapping of zone to resource group ID. Multiple zones -> ID mappings
 can be listed by using the key ``dns_azure_zoneX`` where X is a unique number.
 At least 1 zone mapping is required.
+
+.. code-block:: ini
+   :name: certbot_azure_default_credential.ini
+   :caption: Example config file using the default Azure credential chain:
+
+   dns_azure_zone1 = example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a5/resourceGroups/dns1
+   dns_azure_zone2 = example.org:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2
 
 .. code-block:: ini
    :name: certbot_azure_service_principal.ini

--- a/tests/dns_azure_test.py
+++ b/tests/dns_azure_test.py
@@ -57,6 +57,10 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
                 'azure_msi_system_assigned': 'true',
                 'azure_zone1': 'example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a5/resourceGroups/dns1',
                 'azure_zone2': 'example.org:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2'
+            }),
+            ('default_credential.ini', {
+                'azure_zone1': 'example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a5/resourceGroups/dns1',
+                'azure_zone2': 'example.org:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2'
             })
         )
         for file, config in config_files:
@@ -229,13 +233,6 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
         txt_values = zone1_txt_records[0].value
         self.assertNotIn(zone1_key, txt_values)
         self.assertIn('someexistingkey', txt_values)
-
-    def test_config_missing_auth(self):
-        # Test no auth info
-        dns_test_common.write({}, self.sp_config.azure_config)
-        with self.assertRaises(errors.PluginError) as cm:
-            self.auth.perform(SINGLE_DOMAIN)
-        self.assertIn('No authentication methods have been configured', cm.exception.args[0])
 
     def test_config_missing_zone_info(self):
         # Test missing mapping list


### PR DESCRIPTION
This PR adds [`DefaultAzureCredential`](https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python) as a fallback in case no authentication method is configured in the INI file.

To implement this, I have:
- Removed the check for authentication methods in `_validate_credentials()`, as having no configuration is now valid.
- Changed the return value in the else case of `_get_azure_credentials()` from `ManagedIdentityCredential` to `DefaultAzureCredential`, as `DefaultAzureCredential` will attempt to use `ManagedIdentityCredential` anyway and this gets us a bunch of other authentication methods essentially for free (such as Azure CLI, shared token cache, Azure Powershell etc).
- Removed the test for missing authentication method config, as it's now valid to have missing authentication config.
- Silenced a couple of noisy loggers.

Looking forward to seeing what you think :)