### PR TITLE
Add support for CertificateCredential auth

### DIFF
--- a/certbot_dns_azure/__init__.py
+++ b/certbot_dns_azure/__init__.py
@@ -49,6 +49,19 @@ At least 1 zone mapping is required.
    dns_azure_zone2 = example.org:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2
 
 .. code-block:: ini
+   :name: certbot_azure_service_principal_certificate.ini
+   :caption: Example config file using a service principal with certificate
+
+   dns_azure_sp_client_id = 912ce44a-0156-4669-ae22-c16a17d34ca5
+   dns_azure_sp_certificate_path = /path/to/certificate.pem
+   dns_azure_tenant_id = ed1090f3-ab18-4b12-816c-599af8a88cf7
+
+   dns_azure_environment = "AzurePublicCloud"
+
+   dns_azure_zone1 = example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a5/resourceGroups/dns1
+   dns_azure_zone2 = example.org:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2
+
+.. code-block:: ini
    :name: certbot_azure_user_msi.ini
    :caption: Example config file using used assigned MSI:
 

--- a/certbot_dns_azure/_internal/dns_azure.py
+++ b/certbot_dns_azure/_internal/dns_azure.py
@@ -207,7 +207,6 @@ class Authenticator(dns_common.DNSAuthenticator):
                 parameters=RecordSet(ttl=self.ttl, txt_records=[TxtRecord(value=[v]) for v in txt_value])
             )
         except HttpResponseError as err:
-            print(f"Zone name: {azure_domain}, record name: {relative_validation_name}, group: {resource_group_name}")
             raise errors.PluginError('Failed to add TXT record to domain '
                                      '{}, error: {}'.format(domain, err))
 

--- a/tests/dns_azure_test.py
+++ b/tests/dns_azure_test.py
@@ -51,6 +51,13 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
                 'azure_zone1': 'example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a5/resourceGroups/dns1',
                 'azure_zone2': 'example.org:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2'
             }),
+            ('sp_cert.ini', {
+                'azure_sp_client_id': '912ce44a-0156-4669-ae22-c16a17d34ca5',
+                'azure_sp_client_secret': 'E-xqXU83Y-jzTI6xe9fs2YC~mck3ZzUih9',
+                'azure_certificate_path': '/path/to/cert.pem',
+                'azure_zone1': 'example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a5/resourceGroups/dns1',
+                'azure_zone2': 'example.org:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2'
+            }),
             ('user_assigned_msi.ini', {
                 'azure_msi_client_id': '912ce44a-0156-4669-ae22-c16a17d34ca5',
                 'azure_zone1': 'example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a5/resourceGroups/dns1',
@@ -67,6 +74,9 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
 
         self.sp_config = mock.MagicMock(
             azure_config=os.path.join(self.tempdir, 'sp.ini'),
+            azure_propagation_seconds=0)
+        self.sp_cert_config = mock.MagicMock(
+            azure_config=os.path.join(self.tempdir, 'sp_cert.ini'),
             azure_propagation_seconds=0)
         self.umsi_config = mock.MagicMock(
             azure_config=os.path.join(self.tempdir, 'user_assigned_msi.ini'),


### PR DESCRIPTION
Adds support for `CertificateCredential` service principal authentication.

- Modified `_validate_credentials` to check for either a client secret or a certificate path.
- Modified `_get_azure_credentials` and `_setup_credentials` to include the new parameter and return a `CertificateCredential` if a path is set.
- Added a mock config to `dns_azure_test.py` to match other config options.
- Added example of SP certificate auth to documentation.

Let me know if there are any issues or changes you'd like to see.