### PR TITLE
Use dns zone if available in resource ID

### DIFF
--- a/certbot_dns_azure/__init__.py
+++ b/certbot_dns_azure/__init__.py
@@ -118,6 +118,29 @@ The supported values are:
 ``AzureGermanCloud``                      https://management.microsoftazure.de/
 ========================================  =====================================
 
+DNS delegation
+--------------
+DNS delegation, also known as DNS aliasing, is a process of allowing a secondary DNS zone to handle validation in place
+of the primary zone. For example, you would like to acquire a certificate for ``example.com`` but have the validation
+performed on a secondary domain ``example.org``. You would create a ``_acme-challenge.example.com`` CNAME on the
+``example.com`` nameserver with the value of ``_acme-challenge.example.org``. Certbot will resolve the CNAME and
+validate the ``example.com`` domain.
+
+The common reasons for DNS delegation are:
+ * The primary DNS zone is hosted on a nameserver with no API access
+ * Security concerns regarding access to the primary DNS zone
+
+To use DNS delegation:
+ #. Manually create the ``_acme-challenge.<primary domain>`` CNAME with the value ``_acme-challenge.<secondary domain>`` on the ``example.com`` nameserver.
+ #. In the certbot azure configuration file, specify the primary domain and the entire secondary DNS zone's resource ID in ``dns_azure_zoneX``.
+ #. Request the certificate.
+
+.. code-block:: ini
+   :name: certbot_azure_system_msi.ini
+   :caption: Example configuration snippet for DNS delegation
+
+   dns_azure_zone1 = example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a/resourceGroups/dns1/providers/Microsoft.Network/dnszones/example.org
+   dns_azure_zone2 = example.com:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2/providers/Microsoft.Network/dnszones/acme.example.com
 
 Examples
 --------

--- a/certbot_dns_azure/_internal/dns_azure.py
+++ b/certbot_dns_azure/_internal/dns_azure.py
@@ -160,11 +160,9 @@ class Authenticator(dns_common.DNSAuthenticator):
                 if domain.endswith(azure_dns_domain):
                     subscription_id = resource_group.split('/')[2]
                     rg_name = resource_group.split('/')[4]
-                    try:
-                        azure_dns_zone = resource_group.split('/')[8]
-                    except IndexError:
-                        azure_dns_zone = azure_dns_domain
-                    return azure_dns_zone, subscription_id, rg_name
+                    if '/microsoft.network/dnszones/' in resource_group.lower():
+                        azure_dns_domain = resource_group.split('/')[8]
+                    return azure_dns_domain, subscription_id, rg_name
             else:
                 raise errors.PluginError('Domain {} does not have a valid domain to '
                                          'resource group id mapping'.format(domain))

--- a/certbot_dns_azure/_internal/dns_azure.py
+++ b/certbot_dns_azure/_internal/dns_azure.py
@@ -160,7 +160,11 @@ class Authenticator(dns_common.DNSAuthenticator):
                 if domain.endswith(azure_dns_domain):
                     subscription_id = resource_group.split('/')[2]
                     rg_name = resource_group.split('/')[4]
-                    return azure_dns_domain, subscription_id, rg_name
+                    try:
+                        azure_dns_zone = resource_group.split('/')[8]
+                    except IndexError:
+                        azure_dns_zone = azure_dns_domain
+                    return azure_dns_zone, subscription_id, rg_name
             else:
                 raise errors.PluginError('Domain {} does not have a valid domain to '
                                          'resource group id mapping'.format(domain))

--- a/certbot_dns_azure/_internal/dns_azure.py
+++ b/certbot_dns_azure/_internal/dns_azure.py
@@ -6,6 +6,7 @@ from typing import Dict
 from azure.mgmt.dns import DnsManagementClient
 from azure.mgmt.dns.models import RecordSet, TxtRecord
 from azure.core.exceptions import HttpResponseError
+from azure.core.utils import CaseInsensitiveDict
 from azure.identity import ClientSecretCredential, ManagedIdentityCredential, CertificateCredential
 
 from certbot import errors
@@ -158,14 +159,15 @@ class Authenticator(dns_common.DNSAuthenticator):
             for azure_dns_domain, resource_group in self.domain_zoneid.items():
                 # Look to see if domain ends with key, to cover subdomains
                 if domain.endswith(azure_dns_domain):
-                    subscription_id = resource_group.split('/')[2]
-                    rg_name = resource_group.split('/')[4]
-                    if '/microsoft.network/dnszones/' in resource_group.lower():
-                        try:
-                            azure_dns_domain = resource_group.split('/')[8]
-                        except IndexError:
-                            pass
-
+                    try:
+                        resource = self.parse_azure_resource_id(resource_group)
+                    except ValueError as exc:
+                        raise errors.PluginError('Failed to parse resource ID for {}: {}'
+                                                 .format(domain, resource_group)) from exc
+                    subscription_id = resource.get('subscriptions')
+                    rg_name = resource.get('resourceGroups')
+                    if 'dnsZones' in resource:
+                        azure_dns_domain = resource.get('dnsZones')
                     return azure_dns_domain, subscription_id, rg_name
             else:
                 raise errors.PluginError('Domain {} does not have a valid domain to '
@@ -268,3 +270,20 @@ class Authenticator(dns_common.DNSAuthenticator):
         :rtype: DnsManagementClient
         """
         return DnsManagementClient(self.credential, subscription_id, None, self._arm_endpoint, credential_scopes=[self._arm_endpoint + "/.default"])
+
+    @staticmethod
+    def parse_azure_resource_id(resource_id):
+        rsrc_id = resource_id
+        if rsrc_id.startswith('/'):
+            rsrc_id = rsrc_id[1:]
+
+        if rsrc_id.endswith('/'):
+            rsrc_id = rsrc_id[:-1]
+
+        if '/' not in rsrc_id:
+            raise ValueError('Invalid resource ID: {}'.format(resource_id))
+
+        parts = rsrc_id.split('/')
+        if (len(parts) % 2) != 0 or '' in parts:
+            raise ValueError('Invalid resource ID: {}'.format(resource_id))
+        return CaseInsensitiveDict(zip(parts[0::2], parts[1::2]))

--- a/certbot_dns_azure/_internal/dns_azure.py
+++ b/certbot_dns_azure/_internal/dns_azure.py
@@ -161,7 +161,11 @@ class Authenticator(dns_common.DNSAuthenticator):
                     subscription_id = resource_group.split('/')[2]
                     rg_name = resource_group.split('/')[4]
                     if '/microsoft.network/dnszones/' in resource_group.lower():
-                        azure_dns_domain = resource_group.split('/')[8]
+                        try:
+                            azure_dns_domain = resource_group.split('/')[8]
+                        except IndexError:
+                            pass
+
                     return azure_dns_domain, subscription_id, rg_name
             else:
                 raise errors.PluginError('Domain {} does not have a valid domain to '

--- a/tests/dns_azure_test.py
+++ b/tests/dns_azure_test.py
@@ -294,6 +294,18 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
             self.auth.perform(SINGLE_DOMAIN)
         self.assertIn('DNS Zone mapping is not in the format', cm.exception.args[0])
 
+    def test_config_bad_resource_group(self):
+        # Test invalid resource group ID
+        dns_test_common.write({
+            'azure_sp_client_id': '912ce44a-0156-4669-ae22-c16a17d34ca5',
+            'azure_sp_client_secret': 'E-xqXU83Y-jzTI6xe9fs2YC~mck3ZzUih9',
+            'azure_tenant_id': 'ed1090f3-ab18-4b12-816c-599af8a88cf7',
+            'azure_zone1': 'example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a5/invalid',
+        }, self.sp_config.azure_config)
+        with self.assertRaises(errors.PluginError) as cm:
+            self.auth.perform(SINGLE_DOMAIN)
+        self.assertIn('Failed to parse resource ID for example.com', cm.exception.args[0])
+
 
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/tests/dns_azure_test.py
+++ b/tests/dns_azure_test.py
@@ -131,6 +131,7 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
         self.assertEqual(len(zone2_txt_records), 1)
         self.assertEqual(zone2_txt_records[0].value[0], zone2_key)
 
+        # Test DNS delegation of example.net to example.com
         self.assertEqual(zone3_req.domain, "example.net")
         self.assertEqual(zone3_call[1]['zone_name'], "example.com")
         self.assertEqual(zone3_call[1]['relative_record_set_name'], zone3_relative_record)

--- a/tests/dns_azure_test.py
+++ b/tests/dns_azure_test.py
@@ -20,7 +20,9 @@ MULTI_DOMAIN = [
     achallenges.KeyAuthorizationAnnotatedChallenge(
         challb=acme_util.DNS01, domain='example.com', account_key=KEY),
     achallenges.KeyAuthorizationAnnotatedChallenge(
-        challb=acme_util.DNS01, domain='example.org', account_key=KEY)
+        challb=acme_util.DNS01, domain='example.org', account_key=KEY),
+    achallenges.KeyAuthorizationAnnotatedChallenge(
+        challb=acme_util.DNS01, domain='example.net', account_key=KEY)
 ]
 SINGLE_DOMAIN = [
     achallenges.KeyAuthorizationAnnotatedChallenge(
@@ -49,7 +51,9 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
                 'azure_sp_client_secret': 'E-xqXU83Y-jzTI6xe9fs2YC~mck3ZzUih9',
                 'azure_tenant_id': 'ed1090f3-ab18-4b12-816c-599af8a88cf7',
                 'azure_zone1': 'example.com:/subscriptions/c135abce-d87d-48df-936c-15596c6968a5/resourceGroups/dns1',
-                'azure_zone2': 'example.org:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2'
+                'azure_zone2': 'example.org:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2',
+                'azure_zone3': ('example.net:/subscriptions/99800903-fb14-4992-9aff-12eaf2744622/resourceGroups/dns2'
+                                '/providers/Microsoft.Network/dnsZones/example.com')
             }),
             ('sp_cert.ini', {
                 'azure_sp_client_id': '912ce44a-0156-4669-ae22-c16a17d34ca5',
@@ -95,22 +99,25 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
         self.mock_client.record_sets.get.return_value = RecordSet(txt_records=[])
 
         # Extract zone TXT record name and value
-        zone1_req, zone2_req = MULTI_DOMAIN
+        zone1_req, zone2_req, zone3_req = MULTI_DOMAIN
         zone1_domain_name = zone1_req.validation_domain_name(zone1_req.domain)
         zone1_relative_record = zone1_domain_name.replace('example.com', '').strip('.')
         zone1_key = zone1_req.validation(zone1_req.account_key)
         zone2_domain_name = zone2_req.validation_domain_name(zone2_req.domain)
         zone2_relative_record = zone2_domain_name.replace('example.org', '').strip('.')
         zone2_key = zone2_req.validation(zone2_req.account_key)
+        zone3_domain_name = zone3_req.validation_domain_name(zone3_req.domain)
+        zone3_relative_record = zone3_domain_name.replace('example.com', '').strip('.')
+        zone3_key = zone3_req.validation(zone3_req.account_key)
 
         self.auth.perform(MULTI_DOMAIN)
 
         # Check azure client call counts
-        self.assertEqual(self.mock_client.record_sets.get.call_count, 2)
-        self.assertEqual(self.mock_client.record_sets.create_or_update.call_count, 2)
+        self.assertEqual(self.mock_client.record_sets.get.call_count, 3)
+        self.assertEqual(self.mock_client.record_sets.create_or_update.call_count, 3)
 
         #
-        zone1_call, zone2_call = self.mock_client.record_sets.create_or_update.call_args_list
+        zone1_call, zone2_call, zone3_call = self.mock_client.record_sets.create_or_update.call_args_list
         self.assertEqual(zone1_call[1]['zone_name'], "example.com")
         self.assertEqual(zone1_call[1]['record_type'], "TXT")
         self.assertEqual(zone1_call[1]['relative_record_set_name'], zone1_relative_record)
@@ -123,6 +130,13 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
         zone2_txt_records = zone2_call[1]['parameters'].txt_records
         self.assertEqual(len(zone2_txt_records), 1)
         self.assertEqual(zone2_txt_records[0].value[0], zone2_key)
+
+        self.assertEqual(zone3_req.domain, "example.net")
+        self.assertEqual(zone3_call[1]['zone_name'], "example.com")
+        self.assertEqual(zone3_call[1]['relative_record_set_name'], zone3_relative_record)
+        zone3_txt_records = zone3_call[1]['parameters'].txt_records
+        self.assertEqual(len(zone3_txt_records), 1)
+        self.assertEqual(zone3_txt_records[0].value[0], zone3_key)
 
     def test_perform_existing(self):
         self.mock_client.record_sets.get.return_value = RecordSet(txt_records=[
@@ -188,21 +202,23 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
         self.mock_client.record_sets.get.return_value = RecordSet(txt_records=[])
 
         # Extract zone TXT record name and value
-        zone1_req, zone2_req = MULTI_DOMAIN
+        zone1_req, zone2_req, zone3_req = MULTI_DOMAIN
         zone1_domain_name = zone1_req.validation_domain_name(zone1_req.domain)
         zone2_domain_name = zone2_req.validation_domain_name(zone2_req.domain)
+        zone3_domain_name = zone3_req.validation_domain_name(zone3_req.domain)
         zone1_relative_record = zone1_domain_name.replace('example.com', '').strip('.')
         zone2_relative_record = zone2_domain_name.replace('example.org', '').strip('.')
+        zone3_relative_record = zone3_domain_name.replace('example.com', '').strip('.')
 
         # _attempt_cleanup | pylint: disable=protected-access
         self.auth._attempt_cleanup = True
         self.auth.cleanup(MULTI_DOMAIN)
 
         # Check azure client call counts
-        self.assertEqual(self.mock_client.record_sets.get.call_count, 2)
-        self.assertEqual(self.mock_client.record_sets.delete.call_count, 2)
+        self.assertEqual(self.mock_client.record_sets.get.call_count, 3)
+        self.assertEqual(self.mock_client.record_sets.delete.call_count, 3)
 
-        zone1_call, zone2_call = self.mock_client.record_sets.delete.call_args_list
+        zone1_call, zone2_call, zone3_call = self.mock_client.record_sets.delete.call_args_list
         self.assertEqual(zone1_call[1]['zone_name'], "example.com")
         self.assertEqual(zone1_call[1]['record_type'], "TXT")
         self.assertEqual(zone1_call[1]['relative_record_set_name'], zone1_relative_record)
@@ -210,6 +226,10 @@ class AuthenticatorTest(test_util.TempDirTestCase, dns_test_common.BaseAuthentic
         self.assertEqual(zone2_call[1]['zone_name'], "example.org")
         self.assertEqual(zone2_call[1]['record_type'], "TXT")
         self.assertEqual(zone2_call[1]['relative_record_set_name'], zone2_relative_record)
+
+        self.assertEqual(zone3_call[1]['zone_name'], "example.com")
+        self.assertEqual(zone3_call[1]['record_type'], "TXT")
+        self.assertEqual(zone3_call[1]['relative_record_set_name'], zone3_relative_record)
 
     def test_cleanup_existing(self):
         self.mock_client.record_sets.get.return_value = RecordSet(txt_records=[


### PR DESCRIPTION
We have a subdomain, acme.example.com, in Azure DNS that handles the DNS validation. The DNS zone for example.com is hosted outside of Azure DNS. It has a CNAME that points to acme.example.com: `_acme-challenge.foo.example.com => _acme-challenge.foo.acme.example.com` that will be followed by the ACME server to validate (DNS aliasing).

The current implementation of certbot-dns-azure does not take this setup into account.  Registering foo.example.com with the following configuration will result in certbot-dns-azure writing to a non-existent Azure DNS zone for example.com

`dns_azure_zone1 = example.com:/subscriptions/<subid>/resourceGroups/<rgname>`

Also, adjusting the domain name prefix to `acme.example.com:/subscriptions/...` leads to an error in the plugin: `Domain foo.example.com does not have a valid domain to resource group id mapping`. This makes sense because foo.example.com does not end with acme.example.com. Removing this check would probably fix it in my case, but it's also not the most common case.

With this PR, one can supply the full resource ID with the DNS zone in the configuration file as displayed in Azure DNS.
![image](https://user-images.githubusercontent.com/1482847/170172682-8d7923de-0c06-47b2-b719-169ff7fa9ec8.png)

`dns_azure_zone1 = example.com:/subscriptions/<subid>/resourceGroups/<rgname>/providers/Microsoft.Network/dnszones/acme.example.com`

The code will then attempt to index the DNS zone from resource ID. In this instance, acme.example.com will be returned.  Otherwise, if a resource ID without the dnszone is supplied, it will return example.com as defined in the domain prefix and continue to work as before as currently documented.