### PR TITLE
remove zope

### DIFF
--- a/certbot_dns_azure/_internal/dns_azure.py
+++ b/certbot_dns_azure/_internal/dns_azure.py
@@ -3,22 +3,18 @@ import logging
 from os import getenv
 from typing import Dict
 
-import zope.interface
 from azure.mgmt.dns import DnsManagementClient
 from azure.mgmt.dns.models import RecordSet, TxtRecord
 from azure.core.exceptions import HttpResponseError
 from azure.identity import ClientSecretCredential, ManagedIdentityCredential, CertificateCredential
 
 from certbot import errors
-from certbot import interfaces
 from certbot.plugins import dns_common
 
 logger = logging.getLogger(__name__)
 logging.getLogger('azure').setLevel(logging.WARNING)
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for Azure DNS
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ install_requires = [
     'azure-identity>=1.5.0',
     'azure-mgmt-dns>=8.0.0',
     'setuptools>=39.0.1',
-    'zope.interface',
 ]
 
 with open("README.md") as f:

--- a/snap-requirements.txt
+++ b/snap-requirements.txt
@@ -1,4 +1,3 @@
 azure-identity>=1.5.0
 azure-mgmt-dns>=8.0.0
 setuptools>=39.0.1
-zope.interface>=5.4.0


### PR DESCRIPTION
zope has been deprecated since the release of Certbot 1.19.0 and the referenced interfaces will be removed in an upcoming version of Certbot.