### PR TITLE
Updates azure-identity to fix #23

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ version = '1.5.0'
 # azure-mgmt-dns is still the old style SDK, so will change dramatically
 # when they refactor, most notably the credential parts
 install_requires = [
-    'azure-identity>=1.5.0',
+    'azure-identity>=1.11.0',
     'azure-mgmt-dns>=8.0.0',
     'setuptools>=39.0.1',
     'zope.interface',

--- a/snap-requirements.txt
+++ b/snap-requirements.txt
@@ -1,4 +1,4 @@
-azure-identity>=1.5.0
+azure-identity>=1.11.0
 azure-mgmt-dns>=8.0.0
 setuptools>=39.0.1
 zope.interface>=5.4.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,7 @@ parts:
         snapcraftctl pull
         snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
     build-environment:
-      - PIP_CONSTRAINT: $SNAPCRAFT_PART_SRC/snap-constraints.txt
+#      - PIP_CONSTRAINT: $SNAPCRAFT_PART_SRC/snap-constraints.txt
       - SNAP_BUILD: "True"
     requirements:
       - snap-requirements.txt


### PR DESCRIPTION
A quick hack, really, but it works for me.

I'm not sure why I had to comment out the PIP_CONSTRAINT variable in the build_environment section of snapcraft.yaml to get it to build; I suspect that should be reverted if this gets merged.
