### PR TITLE
Hardcode azure-mgmt-dns version to 8.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ version = '2.6.1'
 # when they refactor, most notably the credential parts
 install_requires = [
     'azure-identity>=1.19.0',
-    'azure-mgmt-dns>=8.2.0',
+    'azure-mgmt-dns=8.2.0',
     'azure-core>=1.32.0',
     'setuptools>=41.6.0',
     'certbot>=3.0,<4.0',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ version = '2.6.1'
 # when they refactor, most notably the credential parts
 install_requires = [
     'azure-identity>=1.19.0',
-    'azure-mgmt-dns=8.2.0',
+    'azure-mgmt-dns>=8.2.0,<9.0',
     'azure-core>=1.32.0',
     'setuptools>=41.6.0',
     'certbot>=3.0,<4.0',

--- a/snap-requirements.txt
+++ b/snap-requirements.txt
@@ -1,5 +1,5 @@
 azure-identity>=1.19.0
-azure-mgmt-dns>=8.2.0
+azure-mgmt-dns>=8.2.0,<9.0
 azure-core>=1.32.0
 setuptools>=41.6.0
 certbot>=3.0,<4.0


### PR DESCRIPTION
New version of azure-mgmt-dns library [(9.0.0) was released 2025-07-14](https://pypi.org/project/azure-mgmt-dns/). This version has several breaking changes, the one I hit was in `DnsManagementClient` initialisation. This class no longer has same fields, which causes following exception in certbot-dns-azure-plugin:

```
Encountered exception during recovery: TypeError: DnsManagementClient.__init__() takes from 3 to 4 positional arguments but 5 were given An unexpected error occurred:
TypeError: DnsManagementClient.__init__() takes from 3 to 4 positional arguments but 5 were given 
```