### PR TITLE
Allow Certbot Version >5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     'azure-mgmt-dns>=8.2.0',
     'azure-core>=1.32.0',
     'setuptools>=41.6.0',
-    'certbot>=3.0,<4.0',
+    'certbot>=3.0,<5.2',
 ]
 
 with open("README.md") as f:

--- a/snap-requirements.txt
+++ b/snap-requirements.txt
@@ -2,4 +2,4 @@ azure-identity>=1.19.0
 azure-mgmt-dns>=8.2.0
 azure-core>=1.32.0
 setuptools>=41.6.0
-certbot>=3.0,<4.0
+certbot>=3.0,<5.2


### PR DESCRIPTION
This is the updated PR from https://github.com/terricain/certbot-dns-azure/pull/57

It closes issue https://github.com/terricain/certbot-dns-azure/issues/56

I need this to use the dns delegation feature in nginxproxymanager (related PR: https://github.com/NginxProxyManager/nginx-proxy-manager/pull/4816)